### PR TITLE
Add docker/ghcopilot.yaml to build ghcopilot image from openaf/mini-a

### DIFF
--- a/docker/ghcopilot.yaml
+++ b/docker/ghcopilot.yaml
@@ -1,0 +1,106 @@
+# Author: Nuno Aguiar
+help:
+  text   : Builds a docker image based on openaf/mini-a with the ghcopilot oPack and GitHub Copilot CLI.
+  expects:
+  - name     : name
+    desc     : Docker image name
+    example  : openaf/ghcopilot
+    mandatory: false
+  - name     : tag
+    desc     : openaf/mini-a tag to use as base image
+    example  : latest
+    mandatory: false
+
+init:
+  dockerfile: |
+    FROM openaf/mini-a:{{tag}}
+
+    USER root
+    RUN apk update \
+     && apk add --no-cache github-cli git \
+     && gh extension install github/gh-copilot --force \
+     && /openaf/opack install ghcopilot
+
+    ENV OAF_MINI_A_LIBS="@AWS/aws.js,@ghcopilot/ghcopilot.js"
+
+    USER openaf
+
+todo:
+- Check for docker
+- Build ghcopilot docker image
+
+include:
+- ojob.io/docker/_common
+
+ojob:
+  opacks      :
+  - openaf: 20231222
+  catch       : printErrnl("[" + job.name + "] "); $err(exception, __, __, job.exec)
+  logToConsole: true   # to change when finished
+
+jobs:
+# ----------------------------------
+- name : Build ghcopilot docker image
+  check:
+    in:
+      name: isString.default("openaf/ghcopilot")
+      tag : isString.default("latest")
+  exec : | #js
+    var dockerfile = "ojob_ghcopilot_" + genUUID() + ".Dockerfile"
+
+    try {
+      io.writeFileString(dockerfile, templify(args.init.dockerfile, {
+        tag: args.tag
+      }))
+
+      print("🔨 Building docker image " + args.name + " from openaf/mini-a:" + args.tag + "...")
+      var cmds = ["docker", "build", "--pull", "--no-cache", "-t", args.name, "-f", dockerfile, "."]
+      var res = $sh(cmds).prefix("build").get(0)
+      if (res.exitcode != 0) throw "Docker build failed: " + res.stderr
+
+      print("✅ Docker image " + args.name + " built successfully.")
+    } finally {
+      if (io.fileExists(dockerfile)) io.rm(dockerfile)
+    }
+
+# ------------------------------
+- name : Build and usage
+  from:
+  - Build ghcopilot docker image
+  to:
+  - (printmd): |
+      ---
+
+      ✅ Docker image `{{name}}` is ready.
+
+      ### Quick usage
+
+      ```bash
+      docker run --rm -ti {{name}}
+      ```
+
+      ### Authenticate GitHub CLI and Copilot
+
+      ```bash
+      docker run --rm -ti {{name}} gh auth login
+      docker run --rm -ti {{name}} gh copilot suggest -t shell "list files modified in git"
+      ```
+
+      ### Use mini-a with ghcopilot helpers
+
+      The image sets:
+
+      ```bash
+      OAF_MINI_A_LIBS="@AWS/aws.js,@ghcopilot/ghcopilot.js"
+      ```
+
+      You can launch mini-a directly:
+
+      ```bash
+      docker run --rm -ti {{name}} mini-a
+      ```
+
+      > Tip: mount your workspace when needed:
+      > `docker run --rm -ti -v $(pwd):/work -w /work {{name}}`
+
+      ---

--- a/docker/ghcopilot.yaml
+++ b/docker/ghcopilot.yaml
@@ -8,7 +8,7 @@ help:
     mandatory: false
   - name     : tag
     desc     : openaf/mini-a tag to use as base image
-    example  : latest
+    example  : deb-t8
     mandatory: false
 
 init:
@@ -16,12 +16,17 @@ init:
     FROM openaf/mini-a:{{tag}}
 
     USER root
-    RUN apk update \
-     && apk add --no-cache github-cli git \
-     && gh extension install github/gh-copilot --force \
-     && /openaf/opack install ghcopilot
+    RUN apt-get update \
+     && apt-get install -y --no-install-recommends gh git nodejs npm \
+     && npm install -g @github/copilot \
+     && /openaf/opack install ghcopilot \
+     && printf '%s\n' '#!/bin/sh' 'set -e' '' 'if [ "$#" -eq 0 ]; then' '  exec /openaf/opack exec mini-a' 'fi' '' 'exec "$@"' > /usr/local/bin/ghcopilot-entrypoint \
+     && chmod +x /usr/local/bin/ghcopilot-entrypoint \
+     && rm -rf /var/lib/apt/lists/*
 
     ENV OAF_MINI_A_LIBS="@AWS/aws.js,@ghcopilot/ghcopilot.js"
+    ENTRYPOINT ["/usr/local/bin/ghcopilot-entrypoint"]
+    CMD ["/openaf/opack", "exec", "mini-a"]
 
     USER openaf
 
@@ -43,8 +48,8 @@ jobs:
 - name : Build ghcopilot docker image
   check:
     in:
-      name: isString.default("openaf/ghcopilot")
-      tag : isString.default("latest")
+      name: isString.default("openaf/mini-a-ghc")
+      tag : isString.default("deb-t8")
   exec : | #js
     var dockerfile = "ojob_ghcopilot_" + genUUID() + ".Dockerfile"
 
@@ -83,7 +88,16 @@ jobs:
 
       ```bash
       docker run --rm -ti {{name}} gh auth login
-      docker run --rm -ti {{name}} gh copilot suggest -t shell "list files modified in git"
+      docker run --rm -ti {{name}} copilot
+      ```
+
+      The image build does not require `GH_TOKEN`; authentication is only needed when you
+      actually use Copilot in the container.
+
+      For non-interactive auth you can also pass `GH_TOKEN` or `GITHUB_TOKEN` at runtime:
+
+      ```bash
+      docker run --rm -ti -e GH_TOKEN=... {{name}} copilot
       ```
 
       ### Use mini-a with ghcopilot helpers
@@ -97,7 +111,7 @@ jobs:
       You can launch mini-a directly:
 
       ```bash
-      docker run --rm -ti {{name}} mini-a
+      docker run --rm -ti {{name}}
       ```
 
       > Tip: mount your workspace when needed:


### PR DESCRIPTION
### Motivation
- Provide an oJob to build a Docker image that extends `openaf/mini-a` with OpenAF's `ghcopilot` oPack and the GitHub Copilot CLI for interactive usage.
- Make it easy to produce a ready-to-use image that exposes mini-a helpers and the Copilot tooling with sensible defaults for `name` and `tag`.

### Description
- Added `docker/ghcopilot.yaml` which templates a Dockerfile based on `FROM openaf/mini-a:{{tag}}` and switches to `USER root` to install `github-cli`, `git`, the `github/gh-copilot` `gh` extension and runs `/openaf/opack install ghcopilot`.
- The image sets `ENV OAF_MINI_A_LIBS="@AWS/aws.js,@ghcopilot/ghcopilot.js"` and restores `USER openaf` at the end of the Dockerfile.
- Implemented an oJob `Build ghcopilot docker image` that writes a temporary Dockerfile, runs `docker build --pull --no-cache -t {{name}} -f <tempfile> .`, and cleans up the tempfile.
- Added a `Build and usage` step which prints usage instructions via the oJob `(printmd)` shortcut including `docker run`, `gh auth login`, `gh copilot` usage and how to launch `mini-a` within the image.

### Testing
- Verified the new file was created and inspected with `nl -ba docker/ghcopilot.yaml` which printed the file contents successfully.
- Committed the new file with `git add` and `git commit`, and the commit completed successfully.
- Attempted to parse the YAML using a small Python snippet with `yaml.safe_load`, but this failed because `PyYAML` is not installed in the environment.  
- Cloned `https://github.com/OpenAF/openaf-dockers` and inspected `mini-a` Dockerfile to confirm the base image and opack patterns.
